### PR TITLE
Fixes use of customPageTitleOptions instead of customPageFooterOptions.

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -50,11 +50,11 @@ function customPageTitle( hook, vm ) {
 }
 
 function debug(msg){
-    if(customPageFooterOptions.debug) console.log(msg);
+    if(customPageTitleOptions.debug) console.log(msg);
 }
 
 function error(msg){
-    if(customPageFooterOptions.debug) console.error(msg);
+    if(customPageTitleOptions.debug) console.error(msg);
 }
 
 


### PR DESCRIPTION
For some reason there was usage of a `customPageFooterOptions` object instead of ` customPageTitleOptions`, which was causing errors as I don't have that object. I believe this should be enough to solve it!