### PR TITLE
Support Index Titles

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,6 +35,10 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
+        if (!_title) {
+            customPageTitleOptions.seprator = false;
+        }
+
         if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
             _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
             debug('new title [prefix]:' + _title);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,8 +36,10 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (document.title == '') {
-            customPageTitleOptions.seprator = '';
+
+        if (document.title = '') {
+            _title = customPageTitleOptions.index;
+            debug('new title [prefix]:' + _title);
         }
 
         if (_index != customPageTitleOptions.index) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,8 +35,8 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (_title == '') {
-            customPageTitleOptions.seprator = false;
+        if (document.title == '') {
+            customPageTitleOptions.seprator = '';
         }
 
         if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -35,7 +35,7 @@ function customPageTitle(hook, vm) {
 
         debug('customPageTitleOptions: ' + customPageTitleOptions);
         debug('page title [before]: ' + document.title);
-        if (!_title) {
+        if (_title == '') {
             customPageTitleOptions.seprator = false;
         }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,7 @@
 
 // config options
 const customPageTitleOptions = {
+    index: 'Docsify',
     prefix: false,
     suffix: false,
     seprator: '|',
@@ -39,14 +40,16 @@ function customPageTitle(hook, vm) {
             customPageTitleOptions.seprator = '';
         }
 
-        if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
-            _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
-            debug('new title [prefix]:' + _title);
-        }
+        if (_index != customPageTitleOptions.index) {
+            if (customPageTitleOptions.prefix != '' || customPageTitleOptions.prefix != false) {
+                _title = customPageTitleOptions.prefix + " " + customPageTitleOptions.seprator + " " + _title;
+                debug('new title [prefix]:' + _title);
+            }
 
-        if (customPageTitleOptions.suffix != '' || customPageTitleOptions.suffix != false) {
-            _title = _title + " " + customPageTitleOptions.seprator + " " + customPageTitleOptions.suffix;
-            debug('new title [suffix]:' + _title);
+            if (customPageTitleOptions.suffix != '' || customPageTitleOptions.suffix != false) {
+                _title = _title + " " + customPageTitleOptions.seprator + " " + customPageTitleOptions.suffix;
+                debug('new title [suffix]:' + _title);
+            }
         }
 
         document.title = _title;


### PR DESCRIPTION
This is a proposed changed to support Index page titles so that the prefix/suffix does not get added on the Index title (doubling up in some cases the title content).

Please let me know if this does not add any value and i will keep the changes in my own fork but wanted to raise it as a potential improvement.